### PR TITLE
Add FE build step

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,11 +28,13 @@ namespace :frontend do
   desc "Build the frontend with esbuild for deployment"
   task :build do
     sh "touch frontend/styles/jit-refresh.css"
+    sh "npm run esbuild"
   end
 
   desc "Watch the frontend with esbuild during development"
   task :dev do
     sh "touch frontend/styles/jit-refresh.css"
+    sh "npm run esbuild-dev"
   rescue Interrupt
   end
 end


### PR DESCRIPTION
At some point, the actual step for building the FE assets must have been removed. This causes the manifest error. Adding this back in ensures that running `./bin/bridgetown frontend:build` does, in fact, build the frontend.